### PR TITLE
Issue openam#36 Remove dependency on ForgeRock Maven repositories

### DIFF
--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -30,7 +30,7 @@
 
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
@@ -42,24 +42,24 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock</groupId>
+            <groupId>jp.openam</groupId>
             <artifactId>forgerock-build-tools</artifactId>
             <scope>test</scope>
         </dependency>
@@ -83,7 +83,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2014-2015 ForgeRock AS.
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,7 +31,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
     <artifactId>opendj-cli</artifactId>

--- a/opendj-cli/pom.xml
+++ b/opendj-cli/pom.xml
@@ -142,6 +142,7 @@
                 </reportSets>
             </plugin>
 
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -151,6 +152,7 @@
                     </links>
                 </configuration>
             </plugin>
+            -->
         </plugins>
     </reporting>
 </project>

--- a/opendj-copyright-maven-plugin/pom.xml
+++ b/opendj-copyright-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
 
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
@@ -80,7 +80,7 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>org.forgerock</groupId>
+            <groupId>jp.openam</groupId>
             <artifactId>forgerock-build-tools</artifactId>
             <scope>test</scope>
         </dependency>
@@ -94,7 +94,7 @@
 
         <!-- Runtime -->
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
 

--- a/opendj-copyright-maven-plugin/pom.xml
+++ b/opendj-copyright-maven-plugin/pom.xml
@@ -22,6 +22,7 @@
  ! CDDL HEADER END
  !
  !      Copyright 2015 ForgeRock AS.
+ !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
  !
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,7 +31,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -30,7 +30,7 @@
 
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
@@ -47,7 +47,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
@@ -57,17 +57,17 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>i18n-slf4j</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock</groupId>
+            <groupId>jp.openam</groupId>
             <artifactId>forgerock-build-tools</artifactId>
             <scope>test</scope>
         </dependency>
@@ -85,7 +85,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -313,6 +313,7 @@
                 </reportSets>
             </plugin>
 
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -322,6 +323,7 @@
                     </links>
                 </configuration>
             </plugin>
+            -->
         </plugins>
     </reporting>
 </project>

--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,7 +31,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/spi/LdapPromiseWrapper.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/spi/LdapPromiseWrapper.java
@@ -153,6 +153,14 @@ class LdapPromiseWrapper<R, P extends Promise<R, LdapException>> implements Ldap
     }
 
     @Override
+    // @Checkstyle:ignore
+    public <VOUT, EOUT extends Exception> Promise<VOUT, EOUT> then(Function<? super R, VOUT, EOUT> onResult,
+            Function<? super LdapException, VOUT, EOUT> onException,
+            Function<? super RuntimeException, VOUT, EOUT> onRuntimeException) {
+        return wrappedPromise.then(onResult, onException, onRuntimeException);
+    }
+
+    @Override
     public LdapPromise<R> thenOnResultOrException(ResultHandler<? super R> onResult,
                                                   ExceptionHandler<? super LdapException> onException) {
         wrappedPromise.thenOnResultOrException(onResult, onException);
@@ -181,8 +189,28 @@ class LdapPromiseWrapper<R, P extends Promise<R, LdapException>> implements Ldap
 
     @Override
     // @Checkstyle:ignore
+    public <VOUT, EOUT extends Exception> Promise<VOUT, EOUT> thenAsync(AsyncFunction<? super R, VOUT, EOUT> onResult,
+            AsyncFunction<? super LdapException, VOUT, EOUT> onException,
+            AsyncFunction<? super RuntimeException, VOUT, EOUT> onRuntimeException) {
+        return wrappedPromise.thenAsync(onResult, onException, onRuntimeException);
+    }
+
+    @Override
+    // @Checkstyle:ignore
     public <EOUT extends Exception> Promise<R, EOUT> thenCatch(Function<? super LdapException, R, EOUT> onException) {
         return wrappedPromise.thenCatch(onException);
+    }
+
+    @Override
+    public Promise<R, LdapException> thenCatchRuntimeException(
+            Function<? super RuntimeException, R, LdapException> onRuntimeException) {
+        return wrappedPromise.thenCatchRuntimeException(onRuntimeException);
+    }
+
+    @Override
+    public Promise<R, LdapException> thenCatchRuntimeExceptionAsync(
+            AsyncFunction<? super RuntimeException, R, LdapException> onRuntimeException) {
+        return wrappedPromise.thenCatchRuntimeExceptionAsync(onRuntimeException);
     }
 
     @Override

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
 
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
@@ -47,12 +47,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
@@ -86,7 +86,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/opendj-doc-maven-plugin/pom.xml
+++ b/opendj-doc-maven-plugin/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2015 ForgeRock AS.
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,7 +31,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -144,6 +144,7 @@
                 </reportSets>
             </plugin>
 
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -153,6 +154,7 @@
                     </links>
                 </configuration>
             </plugin>
+            -->
         </plugins>
     </reporting>
 </project>

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2013-2015 ForgeRock AS
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,7 +31,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-grizzly/pom.xml
+++ b/opendj-grizzly/pom.xml
@@ -30,7 +30,7 @@
 
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
@@ -49,19 +49,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
@@ -77,7 +77,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock</groupId>
+            <groupId>jp.openam</groupId>
             <artifactId>forgerock-build-tools</artifactId>
             <scope>test</scope>
         </dependency>
@@ -87,7 +87,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,7 +31,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -30,7 +30,7 @@
 
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
@@ -41,12 +41,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-grizzly</artifactId>
         </dependency>
 

--- a/opendj-ldap-sdk-examples/pom.xml
+++ b/opendj-ldap-sdk-examples/pom.xml
@@ -85,6 +85,7 @@
 
     <reporting>
         <plugins>
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -94,6 +95,7 @@
                     </links>
                 </configuration>
             </plugin>
+            -->
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/opendj-ldap-toolkit/pom.xml
+++ b/opendj-ldap-toolkit/pom.xml
@@ -22,6 +22,7 @@
  ! CDDL HEADER END
  !
  !      Copyright 2011-2016 ForgeRock AS.
+ !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,7 +31,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-ldap-toolkit/pom.xml
+++ b/opendj-ldap-toolkit/pom.xml
@@ -30,7 +30,7 @@
 
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
@@ -43,12 +43,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-grizzly</artifactId>
         </dependency>
 
@@ -63,24 +63,24 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>i18n-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-cli</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock</groupId>
+            <groupId>jp.openam</groupId>
             <artifactId>forgerock-build-tools</artifactId>
             <scope>test</scope>
         </dependency>
@@ -90,7 +90,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>i18n-maven-plugin</artifactId>
                 <executions>
                     <execution>
@@ -169,7 +169,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.forgerock.opendj</groupId>
+                        <groupId>jp.openam.opendj</groupId>
                         <artifactId>opendj-doc-maven-plugin</artifactId>
                         <version>${project.version}</version>
                         <executions>

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -21,7 +21,7 @@
 
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
@@ -43,22 +43,22 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>jp.openam.opendj</groupId>
             <artifactId>opendj-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>json-resource</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>json-resource-http</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock</groupId>
+            <groupId>jp.openam</groupId>
             <artifactId>forgerock-build-tools</artifactId>
             <scope>test</scope>
         </dependency>

--- a/opendj-rest2ldap/pom.xml
+++ b/opendj-rest2ldap/pom.xml
@@ -13,6 +13,7 @@
   ! information: "Portions Copyright [year] [name of copyright owner]".
   !
   ! Copyright 2012-2015 ForgeRock AS.
+  ! Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -21,7 +22,7 @@
     <parent>
         <artifactId>opendj-sdk-parent</artifactId>
         <groupId>org.forgerock.opendj</groupId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath>../opendj-sdk-parent/pom.xml</relativePath>
     </parent>
 

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -29,12 +29,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.opendj</groupId>
+        <groupId>jp.openam.opendj</groupId>
         <artifactId>opendj-sdk-bom</artifactId>
         <version>3.0.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>jp.openam.opendj</groupId>
     <artifactId>opendj-sdk-parent</artifactId>
 
     <packaging>pom</packaging>
@@ -79,7 +79,7 @@
         <dependencies>
             <!-- Commons -->
             <dependency>
-                <groupId>org.forgerock</groupId>
+                <groupId>jp.openam</groupId>
                 <artifactId>forgerock-build-tools</artifactId>
                 <version>${forgerock-build-tools.version}</version>
                 <scope>test</scope>
@@ -87,7 +87,7 @@
 
             <!-- OpenDJ SDK -->
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>jp.openam.opendj</groupId>
                 <artifactId>opendj-core</artifactId>
                 <type>test-jar</type>
                 <version>${project.version}</version>
@@ -153,7 +153,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.forgerock.opendj</groupId>
+                    <groupId>jp.openam.opendj</groupId>
                     <artifactId>opendj-copyright-maven-plugin</artifactId>
                     <version>${project.version}</version>
                     <configuration>
@@ -171,7 +171,7 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.forgerock.opendj</groupId>
+                    <groupId>jp.openam.opendj</groupId>
                     <artifactId>opendj-doc-maven-plugin</artifactId>
                     <version>${project.version}</version>
                 </plugin>
@@ -261,7 +261,7 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.forgerock.commons</groupId>
+                    <groupId>jp.openam.commons</groupId>
                     <artifactId>i18n-maven-plugin</artifactId>
                     <version>${i18n-framework.version}</version>
                 </plugin>
@@ -344,7 +344,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.forgerock.opendj</groupId>
+                        <groupId>jp.openam.opendj</groupId>
                         <artifactId>opendj-copyright-maven-plugin</artifactId>
                         <executions>
                             <execution>
@@ -364,7 +364,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.forgerock.opendj</groupId>
+                        <groupId>jp.openam.opendj</groupId>
                         <artifactId>opendj-copyright-maven-plugin</artifactId>
                         <executions>
                             <execution>

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2011-2015 ForgeRock AS.
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,7 +31,7 @@
     <parent>
         <groupId>org.forgerock.opendj</groupId>
         <artifactId>opendj-sdk-bom</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.forgerock.opendj</groupId>

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -57,7 +57,7 @@
     </modules>
 
     <properties>
-        <forgerock-build-tools.version>1.0.2</forgerock-build-tools.version>
+        <forgerock-build-tools.version>1.0.4-SNAPSHOT</forgerock-build-tools.version>
         <forgerock-doc-plugin.version>3.1.0</forgerock-doc-plugin.version>
         <grizzly-framework.version>2.3.23</grizzly-framework.version>
 

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -228,6 +228,7 @@
                     </configuration>
                 </plugin>
 
+                <!--
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
@@ -237,6 +238,7 @@
                         </links>
                     </configuration>
                 </plugin>
+                -->
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>jp.openam</groupId>
         <artifactId>forgerock-parent</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -77,7 +77,7 @@
 
     <properties>
         <opendj.sdk.version>3.0.1-SNAPSHOT</opendj.sdk.version>
-        <i18n-framework.version>1.4.2</i18n-framework.version>
+        <i18n-framework.version>1.4.3-SNAPSHOT</i18n-framework.version>
     </properties>
 
     <dependencyManagement>
@@ -86,7 +86,7 @@
             <dependency>
                 <groupId>jp.openam.commons</groupId>
                 <artifactId>forgerock-bom</artifactId>
-                <version>4.1.1</version>
+                <version>4.1.2-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   ! CDDL HEADER END
   !
   !      Copyright 2015 ForgeRock AS.
+  !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,7 +36,7 @@
 
     <groupId>org.forgerock.opendj</groupId>
     <artifactId>opendj-sdk-bom</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -152,7 +153,7 @@
             scp://community.internal.forgerock.com/var/www/vhosts/opendj.forgerock.org/httpdocs
         </site.distribution.url>
 
-        <opendj.sdk.version>3.0.0</opendj.sdk.version>
+        <opendj.sdk.version>3.0.1-SNAPSHOT</opendj.sdk.version>
         <i18n-framework.version>1.4.2</i18n-framework.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,14 +27,14 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.forgerock</groupId>
+        <groupId>jp.openam</groupId>
         <artifactId>forgerock-parent</artifactId>
         <version>2.0.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.forgerock.opendj</groupId>
+    <groupId>jp.openam.opendj</groupId>
     <artifactId>opendj-sdk-bom</artifactId>
     <version>3.0.1-SNAPSHOT</version>
 
@@ -84,7 +84,7 @@
         <dependencies>
             <!-- ForgeRock BOM -->
             <dependency>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>forgerock-bom</artifactId>
                 <version>4.1.1</version>
                 <scope>import</scope>
@@ -93,13 +93,13 @@
 
             <!-- I18N framework -->
             <dependency>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>i18n-core</artifactId>
                 <version>${i18n-framework.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>i18n-slf4j</artifactId>
                 <version>${i18n-framework.version}</version>
             </dependency>
@@ -107,25 +107,25 @@
 
             <!-- OpenDJ SDK -->
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>jp.openam.opendj</groupId>
                 <artifactId>opendj-core</artifactId>
                 <version>${opendj.sdk.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>jp.openam.opendj</groupId>
                 <artifactId>opendj-cli</artifactId>
                 <version>${opendj.sdk.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>jp.openam.opendj</groupId>
                 <artifactId>opendj-grizzly</artifactId>
                 <version>${opendj.sdk.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.forgerock.opendj</groupId>
+                <groupId>jp.openam.opendj</groupId>
                 <artifactId>opendj-rest2ldap</artifactId>
                 <version>${opendj.sdk.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,60 +46,18 @@
         which are known to be compatible with each other.
     </description>
     <inceptionYear>2011</inceptionYear>
-    <url>http://opendj.forgerock.org</url>
+    <url>https://github.com/openam-jp/opendj-sdk</url>
 
     <issueManagement>
-        <system>Jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/OPENDJSDK</url>
+        <system>GitHub</system>
+        <url>https://github.com/openam-jp/opendj-sdk/issues</url>
     </issueManagement>
 
-    <mailingLists>
-        <mailingList>
-            <name>OpenDJ Users Mailing List</name>
-            <archive>http://lists.forgerock.org/pipermail/opendj/</archive>
-            <subscribe>https://lists.forgerock.org/mailman/listinfo/opendj/</subscribe>
-            <unsubscribe>https://lists.forgerock.org/mailman/listinfo/opendj/</unsubscribe>
-            <post>opendj@forgerock.org</post>
-        </mailingList>
-
-        <mailingList>
-            <name>OpenDJ Developers Mailing List</name>
-            <archive>http://lists.forgerock.org/pipermail/opendj-dev/</archive>
-            <subscribe>https://lists.forgerock.org/mailman/listinfo/opendj-dev/</subscribe>
-            <unsubscribe>https://lists.forgerock.org/mailman/listinfo/opendj-dev/</unsubscribe>
-            <post>opendj-dev@forgerock.org</post>
-        </mailingList>
-    </mailingLists>
-
     <scm>
-        <url>https://stash.forgerock.org/projects/OPENDJ/repos/opendj-sdk/browse</url>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj-sdk.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/opendj/opendj-sdk.git</developerConnection>
-        <tag>3.0.0</tag>
+        <connection>scm:git:https://github.com/openam-jp/opendj-sdk.git</connection>
+        <developerConnection>scm:git:git@github.com:openam-jp/opendj-sdk.git</developerConnection>
+        <url>https://github.com/openam-jp/opendj-sdk</url>
     </scm>
-
-    <ciManagement>
-        <system>jenkins</system>
-        <url>https://ci.forgerock.org/view/OpenDJ/job/OpenDJ%20-%20SDK%20-%20postcommit</url>
-        <notifiers>
-            <notifier>
-                <type>mail</type>
-                <sendOnError>true</sendOnError>
-                <sendOnFailure>true</sendOnFailure>
-                <sendOnSuccess>false</sendOnSuccess>
-                <sendOnWarning>false</sendOnWarning>
-                <address>opendj-dev@forgerock.org</address>
-            </notifier>
-        </notifiers>
-    </ciManagement>
-
-    <distributionManagement>
-        <site>
-            <id>forgerock.org</id>
-            <name>OpenDJ Community</name>
-            <url>${site.distribution.url}</url>
-        </site>
-    </distributionManagement>
 
     <licenses>
         <license>
@@ -113,46 +71,11 @@
         </license>
     </licenses>
 
-    <repositories>
-        <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-
-        <repository>
-            <id>jvnet-nexus-snapshots</id>
-            <url>https://maven.java.net/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <modules>
         <module>opendj-sdk-parent</module>
     </modules>
 
     <properties>
-        <site.distribution.url>
-            scp://community.internal.forgerock.com/var/www/vhosts/opendj.forgerock.org/httpdocs
-        </site.distribution.url>
-
         <opendj.sdk.version>3.0.1-SNAPSHOT</opendj.sdk.version>
         <i18n-framework.version>1.4.2</i18n-framework.version>
     </properties>


### PR DESCRIPTION
## Analysis
This is OpenDJ SDK project.

In order to fix openam-jp/openam#36, this project also needs modification.

## Solution

* Remove ForgeRock repository tags in pom.xml
* Change Maven groupId
* Adjust maven dependency

## Install/Update
N/A

## Compatibility
N/A

## Performance
N/A

## I18N
N/A

## Testing
```
$ mvn install -f forgerock-parent
$ mvn install -f forgerock-bom
$ mvn install -f forgerock-build-tools
$ mvn install -f forgerock-i18n-framework
$ mvn install -f forgerock-guice
$ mvn install -f forgerock-guava
$ mvn install -f forgerock-ui
$ mvn install -DskipTests -f forgerock-commons
$ mvn install -f opendj-sdk
```

## Regression testing
N/A