### PR TITLE
Issue openam#33 Upgrade unit testing frameworks

### DIFF
--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/AbstractAsynchronousConnectionTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/AbstractAsynchronousConnectionTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2010 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.opendj.ldap;
@@ -57,7 +58,6 @@ import static org.forgerock.opendj.ldap.TestCaseUtils.*;
 import static org.forgerock.opendj.ldap.requests.Requests.*;
 import static org.forgerock.opendj.ldap.responses.Responses.*;
 import static org.forgerock.opendj.ldap.spi.LdapPromises.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/ConnectionPoolTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/ConnectionPoolTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2010 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.opendj.ldap;
@@ -47,7 +48,6 @@ import static org.fest.assertions.Assertions.*;
 import static org.forgerock.opendj.ldap.Connections.*;
 import static org.forgerock.opendj.ldap.LdapException.*;
 import static org.forgerock.opendj.ldap.TestCaseUtils.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/HeartBeatConnectionFactoryTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/HeartBeatConnectionFactoryTestCase.java
@@ -325,7 +325,7 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
         when(hbcf.timeService.now()).thenReturn(11001L);
         scheduler.runAllTasks(); // Invokes HBCF.ConnectionImpl.sendHeartBeat()
         verify(ldapConnection, times(1)).searchAsync(same(HEARTBEAT),
-        		                             nullable(IntermediateResponseHandler.class),
+                                                     nullable(IntermediateResponseHandler.class),
                                                      nullable(SearchResultHandler.class));
 
         // Send fake bind response, releasing the heartbeat.

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/HeartBeatConnectionFactoryTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/HeartBeatConnectionFactoryTestCase.java
@@ -22,6 +22,8 @@
  *
  *
  *      Copyright 2013-2015 ForgeRock AS.
+ *
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.opendj.ldap;
@@ -44,10 +46,6 @@ import static org.forgerock.opendj.ldap.spi.LdapPromises.newFailedLdapPromise;
 import static org.forgerock.opendj.ldap.spi.LdapPromises.newSearchLdapPromise;
 import static org.forgerock.opendj.ldap.spi.LdapPromises.newSuccessfulLdapPromise;
 import static org.forgerock.util.time.Duration.duration;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.*;
 
 import java.util.LinkedList;
@@ -159,16 +157,16 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
         final SearchResultLdapPromiseImpl heartBeatPromise =
                 newSearchLdapPromise(-1, HEARTBEAT, null, null, ldapConnection);
         when(ldapConnection.searchAsync(same(HEARTBEAT),
-                                        any(IntermediateResponseHandler.class),
-                                        any(SearchResultHandler.class)))
+                                        nullable(IntermediateResponseHandler.class),
+                                        nullable(SearchResultHandler.class)))
                 .thenReturn(heartBeatPromise);
         when(hbcf.timeService.now()).thenReturn(11000L);
         scheduler.runAllTasks(); // Send the heartbeat.
 
         // Capture the heartbeat search result handler.
         verify(ldapConnection, times(2)).searchAsync(same(HEARTBEAT),
-                                                     any(IntermediateResponseHandler.class),
-                                                     any(SearchResultHandler.class));
+                                                     nullable(IntermediateResponseHandler.class),
+                                                     nullable(SearchResultHandler.class));
         assertThat(hbc.isValid()).isTrue(); // Not checked yet.
 
         /*
@@ -176,11 +174,11 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
          * heart beat completes.
          */
         hbc.bindAsync(newSimpleBindRequest());
-        verify(ldapConnection, times(0)).bindAsync(any(BindRequest.class), any(IntermediateResponseHandler.class));
+        verify(ldapConnection, times(0)).bindAsync(nullable(BindRequest.class), nullable(IntermediateResponseHandler.class));
 
         // Send fake heartbeat response, releasing the bind request.
         heartBeatPromise.getWrappedPromise().handleResult(newResult(SUCCESS));
-        verify(ldapConnection, times(1)).bindAsync(any(BindRequest.class), any(IntermediateResponseHandler.class));
+        verify(ldapConnection, times(1)).bindAsync(nullable(BindRequest.class), nullable(IntermediateResponseHandler.class));
     }
 
     @Test
@@ -201,7 +199,7 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
         assertThat(hbc).isNotNull();
         assertThat(hbc.isValid()).isTrue();
 
-        verify(mockResultHandler).handleResult(any(Connection.class));
+        verify(mockResultHandler).handleResult(nullable(Connection.class));
         verifyNoMoreInteractions(mockResultHandler);
     }
 
@@ -321,14 +319,14 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
         when(hbcf.timeService.now()).thenReturn(11000L);
         hbc.bindAsync(newSimpleBindRequest());
 
-        verify(ldapConnection, times(1)).bindAsync(any(BindRequest.class), any(IntermediateResponseHandler.class));
+        verify(ldapConnection, times(1)).bindAsync(nullable(BindRequest.class), nullable(IntermediateResponseHandler.class));
 
         // Verify no heartbeat is sent because there is a bind in progress.
         when(hbcf.timeService.now()).thenReturn(11001L);
         scheduler.runAllTasks(); // Invokes HBCF.ConnectionImpl.sendHeartBeat()
         verify(ldapConnection, times(1)).searchAsync(same(HEARTBEAT),
-                                                     any(IntermediateResponseHandler.class),
-                                                     any(SearchResultHandler.class));
+        		                             nullable(IntermediateResponseHandler.class),
+                                                     nullable(SearchResultHandler.class));
 
         // Send fake bind response, releasing the heartbeat.
         when(hbcf.timeService.now()).thenReturn(11099L);
@@ -350,14 +348,14 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
         // Send another bind request which will timeout.
         when(hbcf.timeService.now()).thenReturn(20000L);
         hbc.bindAsync(newSimpleBindRequest());
-        verify(ldapConnection, times(1)).bindAsync(any(BindRequest.class), any(IntermediateResponseHandler.class));
+        verify(ldapConnection, times(1)).bindAsync(nullable(BindRequest.class), nullable(IntermediateResponseHandler.class));
 
         // Verify no heartbeat is sent because there is a bind in progress.
         when(hbcf.timeService.now()).thenReturn(20001L);
         scheduler.runAllTasks(); // Invokes HBCF.ConnectionImpl.sendHeartBeat()
         verify(ldapConnection, times(1)).searchAsync(same(HEARTBEAT),
-                                                     any(IntermediateResponseHandler.class),
-                                                     any(SearchResultHandler.class));
+                                                     nullable(IntermediateResponseHandler.class),
+                                                     nullable(SearchResultHandler.class));
 
         // Check that lack of bind response acts as heartbeat timeout.
         assertThat(hbc.isValid()).isTrue();
@@ -375,7 +373,7 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
         hbc = hbcf.getConnection();
         hbc.bindAsync(newSimpleBindRequest());
 
-        verify(ldapConnection, times(1)).bindAsync(any(BindRequest.class), any(IntermediateResponseHandler.class));
+        verify(ldapConnection, times(1)).bindAsync(nullable(BindRequest.class), nullable(IntermediateResponseHandler.class));
 
         /*
          * Now attempt the heartbeat which should not happen because there is a
@@ -385,8 +383,8 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
         // Attempt to send the heartbeat.
         scheduler.runAllTasks();
         verify(ldapConnection, times(1)).searchAsync(same(HEARTBEAT),
-                                                     any(IntermediateResponseHandler.class),
-                                                     any(SearchResultHandler.class));
+                                                     nullable(IntermediateResponseHandler.class),
+                                                     nullable(SearchResultHandler.class));
 
         // Send fake bind response, releasing the heartbeat.
         promise.getWrappedPromise().handleResult(newBindResult(SUCCESS));
@@ -396,8 +394,8 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
         // Attempt to send the heartbeat.
         scheduler.runAllTasks();
         verify(ldapConnection, times(2)).searchAsync(same(HEARTBEAT),
-                                                     any(IntermediateResponseHandler.class),
-                                                     any(SearchResultHandler.class));
+                                                     nullable(IntermediateResponseHandler.class),
+                                                     nullable(SearchResultHandler.class));
     }
 
     @Test
@@ -431,7 +429,7 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
             }
         });
         TransportProvider provider = mock(TransportProvider.class);
-        when(provider.getLDAPConnectionFactory(anyString(), anyInt(), any(Options.class))).thenReturn(ldapFactory);
+        when(provider.getLDAPConnectionFactory(nullable(String.class), anyInt(), nullable(Options.class))).thenReturn(ldapFactory);
         scheduler = new MockScheduler();
 
         // Create heart beat connection factory.
@@ -450,7 +448,7 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
 
     private BindResultLdapPromiseImpl mockBindAsyncResponse() {
         final BindResultLdapPromiseImpl bindPromise = newBindLdapPromise(-1, null, null, null, ldapConnection);
-        when(ldapConnection.bindAsync(any(BindRequest.class), any(IntermediateResponseHandler.class)))
+        when(ldapConnection.bindAsync(nullable(BindRequest.class), nullable(IntermediateResponseHandler.class)))
                 .thenReturn(bindPromise);
         return bindPromise;
     }
@@ -461,9 +459,9 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
             final List<ConnectionEventListener> listeners,
             final ResultCode resultCode) {
         // @Checkstyle:off
-        when(mockConnection.searchAsync(any(SearchRequest.class),
-                                        any(IntermediateResponseHandler.class),
-                                        any(SearchResultHandler.class))).thenAnswer(new Answer<LdapPromise<Result>>() {
+        when(mockConnection.searchAsync(nullable(SearchRequest.class),
+                                        nullable(IntermediateResponseHandler.class),
+                                        nullable(SearchResultHandler.class))).thenAnswer(new Answer<LdapPromise<Result>>() {
             @Override
             public LdapPromise<Result> answer(final InvocationOnMock invocation) throws Throwable {
                 if (resultCode == null) {
@@ -488,8 +486,8 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
 
     private void verifyHeartBeatSent(final LDAPConnectionImpl connection, final int times) {
         verify(connection, times(times)).searchAsync(same(HEARTBEAT),
-                                                     any(IntermediateResponseHandler.class),
-                                                     any(SearchResultHandler.class));
+                                                     nullable(IntermediateResponseHandler.class),
+                                                     nullable(SearchResultHandler.class));
     }
 
     private static LDAPConnectionImpl mockLDAPConnectionImpl(final List<ConnectionEventListener> listeners) {
@@ -504,7 +502,7 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
                 listeners.add(listener);
                 return null;
             }
-        }).when(mockConnection).addConnectionEventListener(any(ConnectionEventListener.class));
+        }).when(mockConnection).addConnectionEventListener(nullable(ConnectionEventListener.class));
 
         doAnswer(new Answer<Void>() {
             @Override
@@ -514,7 +512,7 @@ public class HeartBeatConnectionFactoryTestCase extends SdkTestCase {
                 listeners.remove(listener);
                 return null;
             }
-        }).when(mockConnection).removeConnectionEventListener(any(ConnectionEventListener.class));
+        }).when(mockConnection).removeConnectionEventListener(nullable(ConnectionEventListener.class));
 
         return mockConnection;
     }

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/TestCaseUtils.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/TestCaseUtils.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2012-2014 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.opendj.ldap;
 
@@ -45,7 +46,7 @@ import org.forgerock.util.time.TimeService;
 
 import static org.fest.assertions.Fail.*;
 import static org.forgerock.opendj.ldap.spi.LdapPromises.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/SchemaBuilderTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/SchemaBuilderTestCase.java
@@ -22,6 +22,7 @@
  *
  *
  *      Portions Copyright 2012-2015 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -32,7 +33,6 @@ import static org.forgerock.opendj.ldap.schema.Schema.*;
 import static org.forgerock.opendj.ldap.schema.SchemaConstants.*;
 import static org.forgerock.opendj.ldap.schema.SchemaOptions.*;
 import static org.forgerock.opendj.ldap.spi.LdapPromises.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import org.forgerock.i18n.LocalizedIllegalArgumentException;

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/SchemaTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/schema/SchemaTestCase.java
@@ -22,6 +22,8 @@
  *
  *
  *      Copyright 2014 ForgeRock AS.
+ *
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.opendj.ldap.schema;
 
@@ -35,7 +37,6 @@ import org.testng.annotations.Test;
 
 import static org.fest.assertions.Assertions.*;
 import static org.forgerock.opendj.ldap.spi.LdapPromises.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldif/ConnectionChangeRecordWriterTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldif/ConnectionChangeRecordWriterTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2012-2014 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.opendj.ldif;
@@ -46,7 +47,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.forgerock.opendj.ldap.LdapException.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldif/ConnectionEntryReaderTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldif/ConnectionEntryReaderTestCase.java
@@ -22,6 +22,8 @@
  *
  *
  *      Copyright 2011-2014 ForgeRock AS
+ *
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.opendj.ldif;
@@ -49,7 +51,6 @@ import static org.fest.assertions.Fail.*;
 import static org.forgerock.opendj.ldap.LdapException.*;
 import static org.forgerock.opendj.ldap.responses.Responses.*;
 import static org.forgerock.opendj.ldap.spi.LdapPromises.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldif/ConnectionEntryWriterTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldif/ConnectionEntryWriterTestCase.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2011 ForgeRock AS
  *      Portions copyright 2012 ForgeRock AS.
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.opendj.ldif;
@@ -39,7 +40,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldif/LDIFChangeRecordReaderTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldif/LDIFChangeRecordReaderTestCase.java
@@ -24,6 +24,7 @@
  *      Copyright 2011 ForgeRock AS
  *      Portions copyright 2012 ForgeRock AS.
  *      Portions Copyright 2014 Manuel Gaupp
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.opendj.ldif;
@@ -57,7 +58,6 @@ import org.forgerock.opendj.ldap.schema.SchemaValidationPolicy.Action;
 import org.testng.annotations.Test;
 
 import static org.fest.assertions.Assertions.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldif/TemplateTagTestcase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldif/TemplateTagTestcase.java
@@ -22,11 +22,12 @@
  *
  *
  *      Copyright 2013-2015 ForgeRock AS.
+ *
+ *      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.opendj.ldif;
 
 import static org.fest.assertions.Assertions.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;

--- a/opendj-grizzly/src/test/java/org/forgerock/opendj/grizzly/GrizzlyLDAPConnectionFactoryTestCase.java
+++ b/opendj-grizzly/src/test/java/org/forgerock/opendj/grizzly/GrizzlyLDAPConnectionFactoryTestCase.java
@@ -22,6 +22,8 @@
  *
  *
  *     Copyright 2013-2015 ForgeRock AS.
+ *
+ *     Portions Copyrighted 2019 OGIS-RI Co., Ltd.
  */
 package org.forgerock.opendj.grizzly;
 
@@ -75,7 +77,6 @@ import static org.forgerock.opendj.ldap.TestCaseUtils.*;
 import static org.forgerock.opendj.ldap.requests.Requests.*;
 import static org.forgerock.opendj.ldap.LDAPConnectionFactory.*;
 import static org.forgerock.util.time.Duration.duration;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -283,7 +283,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.2</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -23,6 +23,7 @@
   !
   !      Copyright 2011-2015 ForgeRock AS.
   !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  !      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -112,7 +113,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -282,7 +283,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>


### PR DESCRIPTION
## Analysis

openam-jp/openam#33

OpenAM uses the following unit testing frameworks.

* TestNG 6.8.5
* AssertJ 2.1.0
* Mockito 1.9.5
* EasyMock 3.2
* Powermock 1.5
* JUnit 4.10

Some frameworks do not support Java 11.
For example, Mockito supports Java 11 from version 2.20.1.


## Solution
Upgrade unit testing frameworks. Then, tests will pass in Java 8 environment.
- TestNG 6.14.3
- AssertJ 3.13.2
- Mockito 2.28.2
- EasyMoch 4.0.2
- PowerMock 2.0.2
- Junit 4.12


## Install/Update
This fix relies on aggregation of dependencies on the BOM.
The unit testing frameworks are updated by BOM.
To apply the fix, get the modules in the following order and build them.

- forgerock-parent
- forgerock-bom
- forgerock-build-tools
- forgerock-i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- forgerock-bloomfilter
- opendj-sdk
- opendj
- openam


## Regression testing
Test results from testframework have not changed.
