### PR TITLE
Issue openam#32 Support Java 11 (OpenJDK 11)

### DIFF
--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -23,6 +23,7 @@
   !
   !      Copyright 2011-2015 ForgeRock AS
   !      Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  !      Portions Copyrighted 2019 OGIS-RI Co., Ltd.
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -46,6 +47,10 @@
     <packaging>bundle</packaging>
 
     <dependencies>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>jp.openam.commons</groupId>
             <artifactId>i18n-core</artifactId>

--- a/opendj-sdk-parent/pom.xml
+++ b/opendj-sdk-parent/pom.xml
@@ -283,7 +283,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>


### PR DESCRIPTION
## Analysis
openam-jp/openam#32

OpenAM now supports Java8.

While Java 8 is supported by various vendors, but public updates of Oracle Java will close soon.
Also, since release 9, the release model has changed.

OpenAM needs to support Java 11, the latest long-term support Java version.

## Solution
Support Java 11 (OpenJDK 11) as development environment and execution environment.

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-bom
- forgerock-build-tools
- forgerock-i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- opendj-sdk
- opendj
- openam
