### PR TITLE
Issue openam#219 Upgrade Jackson library to 2.10.x

### DIFF
--- a/opendj-core/pom.xml
+++ b/opendj-core/pom.xml
@@ -48,8 +48,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jp.openam.commons</groupId>


### PR DESCRIPTION
## Analysis

openam-jp/openam#219

Newer version of Jackson depend on some Jakarta EE library. And these conflict with the libraries included in this project.

* jakarta.xml.bind-api-2.3.2.jar vs jaxb-api-2.3.0.jar

## Solution

Use jakarta.xml.bind-api instead of jaxb-api.

## Testing

Unit tests works fine.
