### PR TITLE
Issue openam#239 TLSv1.2 or higher support

### DIFF
--- a/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
+++ b/opendj-cli/src/main/java/com/forgerock/opendj/cli/ConnectionFactoryProvider.java
@@ -23,6 +23,7 @@
  *
  *      Copyright 2010 Sun Microsystems, Inc.
  *      Portions copyright 2011-2015 ForgeRock AS
+ *      Portions copyright 2021 OGIS-RI Co., Ltd.
  */
 package com.forgerock.opendj.cli;
 
@@ -30,10 +31,7 @@ import static com.forgerock.opendj.cli.ArgumentConstants.*;
 import static com.forgerock.opendj.cli.CliConstants.DEFAULT_LDAP_PORT;
 import static com.forgerock.opendj.cli.CliMessages.*;
 import static com.forgerock.opendj.cli.Utils.getHostNameForLdapUrl;
-import static org.forgerock.opendj.ldap.LDAPConnectionFactory.AUTHN_BIND_REQUEST;
-import static org.forgerock.opendj.ldap.LDAPConnectionFactory.CONNECT_TIMEOUT;
-import static org.forgerock.opendj.ldap.LDAPConnectionFactory.SSL_CONTEXT;
-import static org.forgerock.opendj.ldap.LDAPConnectionFactory.SSL_USE_STARTTLS;
+import static org.forgerock.opendj.ldap.LDAPConnectionFactory.*;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,6 +42,9 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
@@ -347,6 +348,43 @@ public final class ConnectionFactoryProvider {
     }
 
     /**
+     * Return a list of the available TLS protocols to use.
+     *
+     * <p>
+     * All protocols starting with "SSL" are removed. In particular the SSLv2Hello pseudo protocol is removed which will
+     * prevent connections to a server that doesn't have this configured.
+     * </p>
+     * <p>
+     * To override the defaults, set the <em>org.opends.ldaps.protocols</em> system property to a comma-separated list
+     * of desired protocols.
+     * </p>
+     *
+     * @return A list of valid protocol strings.
+     * @throws NoSuchAlgorithmException
+     *         If an SSL context could not be created.
+     */
+    public static List<String> getDefaultProtocols() throws NoSuchAlgorithmException {
+        List<String> enabled = Arrays.asList(SSLContext.getDefault().createSSLEngine().getEnabledProtocols());
+        final String property = System.getProperty("org.opends.ldaps.protocols");
+        final List<String> defaults = new ArrayList<>();
+        if (property != null && property.length() != 0) {
+            for (String protocol : property.split(",")) {
+                if (enabled.contains(protocol)) {
+                    defaults.add(protocol);
+                }
+            }
+            return defaults;
+        }
+        // exclude SSLv2Hello and SSLv3
+        for (String protocol : enabled) {
+            if (!protocol.startsWith("SSL")) {
+                defaults.add(protocol);
+            }
+        }
+        return defaults;
+    }
+
+    /**
      * Constructs a connection factory for pre-authenticated connections. Checks if any conflicting arguments are
      * present, build the connection with selected arguments and returns the connection factory. If the application is
      * interactive, it will prompt the user for missing parameters.
@@ -437,8 +475,13 @@ public final class ConnectionFactoryProvider {
 
             Options options = Options.defaultOptions();
             if (sslContext != null) {
-                options.set(SSL_CONTEXT, sslContext)
-                    .set(SSL_USE_STARTTLS, useStartTLSArg.isPresent());
+                try {
+                    options.set(SSL_CONTEXT, sslContext)
+                            .set(SSL_USE_STARTTLS, useStartTLSArg.isPresent())
+                            .set(SSL_ENABLED_PROTOCOLS, getDefaultProtocols());
+                } catch (NoSuchAlgorithmException e) {
+                    throw new ArgumentException(ERR_LDAP_CONN_CANNOT_INITIALIZE_SSL.get(e.toString()), e);
+                }
             }
             options.set(CONNECT_TIMEOUT, new Duration((long) getConnectTimeout(), TimeUnit.MILLISECONDS));
             if (usePreAuthentication) {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/LDAPConnectionFactory.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/LDAPConnectionFactory.java
@@ -23,13 +23,14 @@
  *
  *      Copyright 2009-2010 Sun Microsystems, Inc.
  *      Portions Copyright 2011-2015 ForgeRock AS.
+ *      Portions copyright 2021 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.opendj.ldap;
 
 import static com.forgerock.opendj.ldap.CoreMessages.HBCF_CONNECTION_CLOSED_BY_CLIENT;
-import static com.forgerock.opendj.ldap.CoreMessages.HBCF_HEARTBEAT_FAILED;
 import static com.forgerock.opendj.ldap.CoreMessages.HBCF_HEARTBEAT_TIMEOUT;
+import static com.forgerock.opendj.ldap.CoreMessages.ERR_CONNECTION_UNEXPECTED;
 import static com.forgerock.opendj.ldap.CoreMessages.LDAP_CONNECTION_CONNECT_TIMEOUT;
 import static com.forgerock.opendj.util.StaticUtils.DEFAULT_SCHEDULER;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -508,7 +509,7 @@ public final class LDAPConnectionFactory extends CommonLDAPOptions implements Co
                         connectException = newHeartBeatTimeoutError();
                     } else {
                         connectException = newLdapException(ResultCode.CLIENT_SIDE_SERVER_DOWN,
-                                                            HBCF_HEARTBEAT_FAILED.get(),
+                                                            ERR_CONNECTION_UNEXPECTED.get(e),
                                                             e);
                     }
                     if (promise.tryHandleException(connectException)) {

--- a/opendj-core/src/main/java/org/forgerock/opendj/ldap/SSLContextBuilder.java
+++ b/opendj-core/src/main/java/org/forgerock/opendj/ldap/SSLContextBuilder.java
@@ -22,6 +22,7 @@
  *
  *
  *      Copyright 2010 Sun Microsystems, Inc.
+ *      Portions copyright 2021 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.opendj.ldap;
@@ -67,36 +68,13 @@ public final class SSLContextBuilder {
     public static final String PROTOCOL_SSL = "SSL";
 
     /**
-     * SSL protocol: supports SSL version 2 or higher; may support other
-     * versions.
-     */
-    public static final String PROTOCOL_SSL2 = "SSLv2";
-
-    /**
-     * SSL protocol: supports SSL version 3; may support other versions.
-     */
-    public static final String PROTOCOL_SSL3 = "SSLv3";
-
-    /**
      * SSL protocol: supports some version of TLS; may support other versions.
      */
     public static final String PROTOCOL_TLS = "TLS";
 
-    /**
-     * SSL protocol: supports RFC 2246: TLS version 1.0 ; may support other
-     * versions.
-     */
-    public static final String PROTOCOL_TLS1 = "TLSv1";
-
-    /**
-     * SSL protocol: supports RFC 4346: TLS version 1.1 ; may support other
-     * versions.
-     */
-    public static final String PROTOCOL_TLS1_1 = "TLSv1.1";
-
     private TrustManager trustManager;
     private KeyManager keyManager;
-    private String protocol = PROTOCOL_TLS1;
+    private String protocol = PROTOCOL_TLS;
     private SecureRandom random;
 
     /** These are mutually exclusive. */
@@ -159,12 +137,12 @@ public final class SSLContextBuilder {
     }
 
     /**
-     * Sets the protocol which the SSL context should use. By default, TLSv1
+     * Sets the protocol which the SSL context should use. By default, TLS
      * will be used.
      *
      * @param protocol
      *            The protocol which the SSL context should use, which may be
-     *            {@code null} indicating that TLSv1 will be used.
+     *            {@code null} indicating that TLS will be used.
      * @return This SSL context builder.
      */
     public SSLContextBuilder setProtocol(final String protocol) {

--- a/opendj-core/src/main/resources/com/forgerock/opendj/ldap/core.properties
+++ b/opendj-core/src/main/resources/com/forgerock/opendj/ldap/core.properties
@@ -24,6 +24,7 @@
 #      Copyright 2010 Sun Microsystems, Inc.
 #      Portions copyright 2011-2015 ForgeRock AS
 #      Portions Copyright 2014 Manuel Gaupp
+#      Portions copyright 2021 OGIS-RI Co., Ltd.
 #
 ERR_ATTR_SYNTAX_UNKNOWN_APPROXIMATE_MATCHING_RULE=Unable to retrieve \
  approximate matching rule %s used as the default for the %s attribute syntax. \
@@ -1643,7 +1644,7 @@ WARN_ATTR_INVALID_PARTIAL_TIME_ASSERTION_FORMAT=The provided \
  value "%s" could not be parsed as a valid assertion value because the \
  character '%c' is not allowed. The acceptable values are s (second), \
  m (minute), h (hour), D (date), M (month) and Y (year)
-ERR_INVALID_COMPACTED_UNSIGNED_INT="Expected a compacted unsigned int (value less than %d), \
+ERR_INVALID_COMPACTED_UNSIGNED_INT=Expected a compacted unsigned int (value less than %d), \
  but got a compacted unsigned long: %d
 ERR_TRANSACTION_ID_CONTROL_BAD_OID=Cannot decode the provided \
  control as a transaction id control because it contained the OID '%s', \
@@ -1671,3 +1672,4 @@ LDAP_CONNECTION_CONNECT_TIMEOUT=The connection attempt to server %s has failed \
  because the connection timeout period of %d ms was exceeded
 LOAD_BALANCER_EVENT_LISTENER_LOG_ONLINE=Connection factory '%s' is now operational
 LOAD_BALANCER_EVENT_LISTENER_LOG_OFFLINE=Connection factory '%s' is no longer operational: %s
+ERR_CONNECTION_UNEXPECTED=An error occurred during establishment of a connection: %s

--- a/opendj-core/src/main/resources/com/forgerock/opendj/ldap/core.properties
+++ b/opendj-core/src/main/resources/com/forgerock/opendj/ldap/core.properties
@@ -1644,7 +1644,7 @@ WARN_ATTR_INVALID_PARTIAL_TIME_ASSERTION_FORMAT=The provided \
  value "%s" could not be parsed as a valid assertion value because the \
  character '%c' is not allowed. The acceptable values are s (second), \
  m (minute), h (hour), D (date), M (month) and Y (year)
-ERR_INVALID_COMPACTED_UNSIGNED_INT=Expected a compacted unsigned int (value less than %d), \
+ERR_INVALID_COMPACTED_UNSIGNED_INT="Expected a compacted unsigned int (value less than %d), \
  but got a compacted unsigned long: %d
 ERR_TRANSACTION_ID_CONTROL_BAD_OID=Cannot decode the provided \
  control as a transaction id control because it contained the OID '%s', \

--- a/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/StartTLSExtendedRequestTestCase.java
+++ b/opendj-core/src/test/java/org/forgerock/opendj/ldap/requests/StartTLSExtendedRequestTestCase.java
@@ -22,6 +22,7 @@
  *
  *
  *      Copyright 2013 ForgeRock AS
+ *      Portions copyright 2021 OGIS-RI Co., Ltd.
  */
 
 package org.forgerock.opendj.ldap.requests;
@@ -105,7 +106,7 @@ public class StartTLSExtendedRequestTestCase extends RequestsTestCase {
     public void testUnmodifiableSetAuthenticationID(final StartTLSExtendedRequest original)
             throws NoSuchAlgorithmException {
         final StartTLSExtendedRequest unmodifiable = (StartTLSExtendedRequest) unmodifiableOf(original);
-        unmodifiable.setSSLContext(SSLContext.getInstance("SSL"));
+        unmodifiable.setSSLContext(SSLContext.getInstance("TLS"));
     }
 
     @Test(dataProvider = "StartTLSExtendedRequests")


### PR DESCRIPTION
## Analysis

openam-jp/openam#239

The OpenDJ SDK, OpenDJ, and OpenAM specify TLSv1.0 as the SSL context protocol.
The current standard version of TLS is TLSv1.2, which causes the following issues:
 - In RHEL 8 / CentOS 8, TLSv1.0 is disabled by the system-wide encryption policy. Therefore, some functions and test code do not work properly.
 - The OpenJDK, scheduled for release in 2021/04, will change the security settings of Java to disable TLSv1.0 and TLSv1.1.


## Solution

Make the OpenDJ SDK, OpenDJ, and OpenAM projects compatible with TLSv1.2 or higher.
Some parts of these projects are hard-coded to use TLSv1.0.
We will revise these parts to be written in an appropriate way to follow TLSv1.2 or higher.
